### PR TITLE
Implement Protocol 408

### DIFF
--- a/cmd/map-console/main.go
+++ b/cmd/map-console/main.go
@@ -813,6 +813,9 @@ func describeIncomingMessage(msg mapper.MessagePayload, mono bool, cal gma.Calen
 			fieldDesc{"i", m.I},
 			fieldDesc{"s", m.S},
 			fieldDesc{"o", describeObject(mono, m.O)},
+			fieldDesc{"ReceivedTime", m.ReceivedTime},
+			fieldDesc{"SentTime", m.SentTime},
+			fieldDesc{"(latency)", m.SentTime.Sub(m.ReceivedTime)},
 		)
 
 	case mapper.LoadFromMessagePayload:

--- a/cmd/server/application.go
+++ b/cmd/server/application.go
@@ -876,7 +876,9 @@ func (a *Application) HandleServerMessage(payload mapper.MessagePayload, request
 		}
 
 	case mapper.EchoMessagePayload:
-		requester.Conn.Send(mapper.Echo, p)
+		if err := requester.Conn.SendEchoWithTimestamp(mapper.Echo, p); err != nil {
+			a.Logf("Error sending ECHO: %v", err)
+		}
 
 	case mapper.FilterDicePresetsMessagePayload:
 		if requester.Auth == nil {

--- a/mapper/mapclient.go
+++ b/mapper/mapclient.go
@@ -3023,15 +3023,41 @@ func (c *Connection) receiveDSM(d UpdateStatusMarkerMessagePayload) {
 
 func (c *Connection) receiveAddCharacter(d AddCharacterMessagePayload) {
 	if c != nil {
-		c.Characters[d.Name] = PlayerToken{
-			CreatureToken: CreatureToken{
-				BaseMapObject: BaseMapObject{
-					ID: d.ObjID(),
-				},
-				Name:  d.Name,
-				Color: d.Color,
-				Size:  d.Size,
+		critter := CreatureToken{
+			BaseMapObject: BaseMapObject{
+				ID: d.ObjID(),
 			},
+			Name:         d.Name,
+			Color:        d.Color,
+			Killed:       d.Killed,
+			Dim:          d.Dim,
+			Hidden:       d.Hidden,
+			PolyGM:       d.PolyGM,
+			CreatureType: CreatureTypePlayer,
+			MoveMode:     d.MoveMode,
+			Reach:        d.Reach,
+			Elev:         d.Elev,
+			Gx:           d.Gx,
+			Gy:           d.Gy,
+			Note:         d.Note,
+			DispSize:     d.DispSize,
+			StatusList:   d.StatusList,
+			CustomReach: CreatureCustomReach{
+				Enabled:  d.CustomReach.Enabled,
+				Natural:  d.CustomReach.Natural,
+				Extended: d.CustomReach.Extended,
+			},
+		}
+		critter.SetSizes(d.SkinSize, d.Skin, d.Size)
+		if d.AoE != nil {
+			critter.AoE = &RadiusAoE{
+				Radius: d.AoE.Radius,
+				Color:  d.AoE.Color,
+			}
+		}
+
+		c.Characters[d.Name] = PlayerToken{
+			CreatureToken: critter,
 		}
 	}
 }

--- a/mapper/mapclient.go
+++ b/mapper/mapclient.go
@@ -1433,10 +1433,12 @@ type DeniedMessagePayload struct {
 type EchoMessagePayload struct {
 	BaseMessagePayload
 
-	B bool           `json:"b,omitempty"`
-	I int            `json:"i,omitempty"`
-	S string         `json:"s,omitempty"`
-	O map[string]any `json:"o,omitempty"`
+	B            bool           `json:"b,omitempty"`
+	I            int            `json:"i,omitempty"`
+	S            string         `json:"s,omitempty"`
+	O            map[string]any `json:"o,omitempty"`
+	ReceivedTime time.Time      `json:",omitempty"`
+	SentTime     time.Time      `json:",omitempty"`
 }
 
 func (c *Connection) EchoString(s string) error {

--- a/mapper/mapobject.go
+++ b/mapper/mapobject.go
@@ -656,6 +656,10 @@ type CreatureToken struct {
 	// If true, this means the creature token is only visible to the GM.
 	Hidden bool `json:",omitempty"`
 
+	// If true, only the GM may access or manipulate the polymorph capabilities
+	// of this creature.
+	PolyGM bool `json:",omitempty"`
+
 	// The creature type.
 	CreatureType CreatureTypeCode
 
@@ -718,6 +722,8 @@ type CreatureToken struct {
 	// category while upper-case indicates "tall" versions.
 	//
 	// May also be the size in feet (DEPRECATED USAGE).
+	//
+	// This field is now DEPRECATED. Use SkinSize instead.
 	Size string
 
 	// If DispSize is nonempty, it holds the size category to display

--- a/mapper/mapobject.go
+++ b/mapper/mapobject.go
@@ -24,6 +24,7 @@ package mapper
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -53,6 +54,12 @@ const MinimumSupportedMapFileFormat = 17
 // can understand. Saved data will be in this format.
 //
 const MaximumSupportedMapFileFormat = 22
+
+// ErrCreatureNoSizes is the error returned when a creature size code is expected but none given.
+var ErrCreatureNoSizes = errors.New("missing creature size code")
+
+// ErrCreatureInvalidSize is the error returned when a creature size code is expected but the code(s) given are invalid.
+var ErrCreatureInvalidSize = errors.New("invalid creature size code")
 
 func init() {
 	if MinimumSupportedMapFileFormat > GMAMapperFileFormat || MaximumSupportedMapFileFormat < GMAMapperFileFormat {
@@ -660,10 +667,10 @@ func (c *CreatureToken) SetSizes(skinSize []string, skin int, size string) error
 	// If no skinSize list was present, just use size as the single item for that list.
 	if len(skinSize) == 0 {
 		if size == "" {
-			return fmt.Errorf("no size specified")
+			return ErrCreatureNoSizes
 		}
 		if sizeCodeRE.FindStringSubmatch(size) == nil {
-			return fmt.Errorf("Size field DEPRECATED; also, size code \"%s\" is invalid", size)
+			return ErrCreatureInvalidSize
 		}
 		c.SkinSize = []string{size}
 		c.Skin = 0
@@ -680,7 +687,7 @@ func (c *CreatureToken) SetSizes(skinSize []string, skin int, size string) error
 				defaultSkinSize = i
 			}
 		} else {
-			return fmt.Errorf("skin #%d size code \"%s\" is invalid", i, ss)
+			return ErrCreatureInvalidSize
 		}
 	}
 

--- a/mapper/mapprotocol.go
+++ b/mapper/mapprotocol.go
@@ -51,10 +51,10 @@ import (
 // and protocol versions supported by this code.
 //
 const (
-	GMAMapperProtocol=407     // @@##@@ auto-configured
-	GoVersionNumber="5.8.3" // @@##@@ auto-configured
+	GMAMapperProtocol           = 408     // @@##@@ auto-configured
+	GoVersionNumber             = "5.8.3" // @@##@@ auto-configured
 	MinimumSupportedMapProtocol = 400
-	MaximumSupportedMapProtocol = 407
+	MaximumSupportedMapProtocol = 408
 )
 
 func init() {

--- a/mapper/mapprotocol.go
+++ b/mapper/mapprotocol.go
@@ -44,6 +44,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 )
 
 //
@@ -98,6 +99,15 @@ func (c *MapConnection) Close() {
 	if c != nil && c.conn != nil {
 		c.conn.Close()
 	}
+}
+
+//
+// SendEchoWithTimestamp is identical to Send, but only takes an EchoMessagePayload parameter
+// and writes the SentTime value into it as it sends it out.
+//
+func (c *MapConnection) SendEchoWithTimestamp(command ServerMessage, data EchoMessagePayload) error {
+	data.SentTime = time.Now()
+	return c.Send(command, data)
 }
 
 //

--- a/mapper/mapserver.go
+++ b/mapper/mapserver.go
@@ -439,6 +439,10 @@ mainloop:
 				case PoloMessagePayload:
 					c.LastPoloTime = time.Now()
 
+				case EchoMessagePayload:
+					p.ReceivedTime = time.Now()
+					c.Server.HandleServerMessage(p, c)
+
 				default:
 					c.Server.HandleServerMessage(packet, c)
 				}


### PR DESCRIPTION
This update adds round-trip timing fields to `ECHO`, deprecates `Size` in favor of the expanded-syntax `SkinSize` in `PS` and adds `PolyGM` to `PS`.