### PR TITLE
Client version filtering

### DIFF
--- a/cmd/server/application.go
+++ b/cmd/server/application.go
@@ -1329,6 +1329,9 @@ func (a *Application) managePreambleData() {
 
 		case "UPDATES":
 			var data mapper.UpdateVersionsMessagePayload
+			if err = json.Unmarshal(s, &data); err == nil {
+				b, err = json.Marshal(data)
+			}
 			a.AllowedClients = data.Packages
 			if a.AllowedClients != nil {
 				for _, aClient := range a.AllowedClients {
@@ -1341,9 +1344,6 @@ func (a *Application) managePreambleData() {
 				}
 			}
 			a.Debugf(DebugInit, "allowed client list is now %v", a.AllowedClients)
-			if err = json.Unmarshal(s, &data); err == nil {
-				b, err = json.Marshal(data)
-			}
 
 		case "WORLD":
 			var data mapper.WorldMessagePayload

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -133,7 +133,7 @@ import (
 // Auto-configured values
 //
 
-const GoVersionNumber="5.10.0" // @@##@@
+const GoVersionNumber="5.11.0-alpha" // @@##@@
 
 //
 // eventMonitor responds to signals and timers that affect our overall operation

--- a/mapper/mapclient.go
+++ b/mapper/mapclient.go
@@ -2607,8 +2607,10 @@ type UpdateVersionsMessagePayload struct {
 }
 
 type PackageUpdate struct {
-	Name      string
-	Instances []PackageVersion
+	Name           string
+	VersionPattern string `json:",omitempty"`
+	MinimumVersion string `json:",omitempty"`
+	Instances      []PackageVersion
 }
 
 type PackageVersion struct {

--- a/mapper/mapserver.go
+++ b/mapper/mapserver.go
@@ -575,7 +575,7 @@ func (c *ClientConnection) loginClient(ctx context.Context, done chan error, ser
 							c.Conn.Send(Denied, DeniedMessagePayload{Reason: "disallowed client version"})
 							_ = c.Conn.Flush()
 							done <- fmt.Errorf("client denied")
-							break
+							return
 						}
 
 						relVer, err := util.VersionCompare(fields[1], allowedClient.MinimumVersion)
@@ -584,7 +584,7 @@ func (c *ClientConnection) loginClient(ctx context.Context, done chan error, ser
 							c.Conn.Send(Denied, DeniedMessagePayload{Reason: "unable to understand client version"})
 							_ = c.Conn.Flush()
 							done <- fmt.Errorf("client version error")
-							break
+							return
 						}
 
 						if relVer < 0 {
@@ -592,6 +592,7 @@ func (c *ClientConnection) loginClient(ctx context.Context, done chan error, ser
 							c.Conn.Send(Denied, DeniedMessagePayload{Reason: allowedClient.Name + " client is older than minimum allowed version"})
 							_ = c.Conn.Flush()
 							done <- fmt.Errorf("client version not allowed")
+							return
 						} else {
 							c.debugf(DebugAuth, "%s client version %s is allowed", allowedClient.Name, fields[1])
 						}


### PR DESCRIPTION
Adds filtering to the server so that the GM/admin can disallow versions older than a certain limit from connecting.