### PR TITLE
redirect termination

### DIFF
--- a/mapper/mapprotocol.go
+++ b/mapper/mapprotocol.go
@@ -52,8 +52,8 @@ import (
 // and protocol versions supported by this code.
 //
 const (
-	GMAMapperProtocol=410              // @@##@@ auto-configured
-	GoVersionNumber="5.13.1" // @@##@@ auto-configured
+	GMAMapperProtocol           = 410              // @@##@@ auto-configured
+	GoVersionNumber             = "5.13.2-alpha.0" // @@##@@ auto-configured
 	MinimumSupportedMapProtocol = 400
 	MaximumSupportedMapProtocol = 410
 )

--- a/mapper/mapserver.go
+++ b/mapper/mapserver.go
@@ -480,6 +480,15 @@ func (c *ClientConnection) loginClient(ctx context.Context, done chan error, ser
 				done <- err
 				return
 			}
+			if strings.HasPrefix(line, "REDIRECT ") {
+				c.debugf(DebugIO, "preamble includes REDIRECT statement; not continuing further")
+				time.Sleep(time.Second * 5)
+				c.Conn.sendRaw("// Disconnecting now. See you on the other server!")
+				c.Conn.Flush()
+				time.Sleep(time.Second * 2)
+				done <- fmt.Errorf("login cancelled due to redirect")
+				return
+			}
 		}
 	}
 


### PR DESCRIPTION
immediately disconnect after issuing `REDIRECT` (used to continue with rest of preamble and issue a login request anyway)